### PR TITLE
Force cronjob to use bash as the shell

### DIFF
--- a/overlay/etc/cron.hourly/openvpn-profiles-delexpired
+++ b/overlay/etc/cron.hourly/openvpn-profiles-delexpired
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 # delete downloaded openvpn client profiles
 
-su www-data -c /var/www/openvpn/bin/delexpired
+su www-data -s /bin/bash -c /var/www/openvpn/bin/delexpired
 


### PR DESCRIPTION
User www-data has the default shell set to /usr/bin/nologin so the su
command in the crojob fails if no shell is forced with -s.